### PR TITLE
fix: use binary installation for golangci-lint in make tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ precommit: fmt lint test
 ## tools: Install development tools
 tools:
 	@echo "Installing development tools..."
-	@$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $$(go env GOPATH)/bin
 	@$(GO) install github.com/mitchellh/gox@latest
 	@$(GO) install mvdan.cc/gofumpt@latest
 	@echo "Tools installed successfully!"


### PR DESCRIPTION
## Summary
- Changes `make tools` to use golangci-lint's recommended binary installation method instead of `go install`
- The `go install` method is explicitly discouraged by golangci-lint maintainers for 7 reasons (docs: https://golangci-lint.run/docs/welcome/install/local/)

## Why this matters
- Binary installation uses pre-compiled, tested binaries
- Avoids local compilation issues with different Go versions
- Faster installation (no compilation step)
- Deterministic - same version always produces identical binary

## Test plan
- [ ] Run `make tools` and verify golangci-lint installs correctly
- [ ] Run `golangci-lint --version` to confirm version
- [ ] Run `make lint` to verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)