### PR TITLE
chore: update .gitignore and add example wt config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ tmp/
 .worktrees/
 
 # wt - project-local config
-.wt.yaml
+.wt.local.yaml

--- a/.wt.yaml
+++ b/.wt.yaml
@@ -1,0 +1,84 @@
+# Example wt GLOBAL configuration file
+# Copy to ~/.config/wt/config.yaml
+#
+# For project-specific settings, create a .wt.yaml file at your repository root.
+# Project config overlays global config with these merge semantics:
+#   - Scalars (strings, bools): project value replaces global
+#   - Arrays (hooks): project array replaces global entirely
+#   - Undefined fields: inherit from global
+
+global:
+  # Prefix for tmux session names
+  tmux_session_prefix: "wt-"
+
+# Hooks run automatically after worktree operations
+# NOTE: These are global defaults. Override in .wt.yaml for project-specific hooks.
+hooks:
+  on_worktree_create:
+    - run: "make build"
+      cwd: "{worktree_path}"
+      background: true
+
+  on_worktree_remove:
+    # Example: Clean up on remove
+    - run: "rm -rf node_modules"
+      cwd: "{worktree_path}"
+
+# Tmux settings
+tmux:
+  # Layout: main-vertical, main-horizontal, even-horizontal, tiled, etc.
+  layout: "main-vertical"
+
+  # Name for the initial window
+  window_name: "work"
+
+  # Automatically attach to session after creation
+  attach_on_create: true
+
+  # Window naming preferences
+  window_naming:
+    # Maximum length for window names (1-32)
+    max_length: 16
+    # Abbreviate issue IDs in window names (e.g., "nova-123" -> "n-123")
+    abbreviate_issue_id: true
+
+# Git-spice configuration for branch stacking
+spice:
+  # Path to git-spice binary. Set this via 'wt init' for auto-detection.
+  # If empty, stacking commands will prompt you to run 'wt init'.
+  binary_path: ""  # Example: "/usr/local/bin/git-spice" or "C:\\Users\\you\\.cargo\\bin\\git-spice.exe"
+
+# Worktree settings
+worktree:
+  # Location mode: "dedicated" (outside repo) or "per-repo" (inside repo)
+  location: "dedicated"
+
+  # Custom path for dedicated mode (default: ~/worktrees)
+  dedicated_path: "~/worktrees"
+
+# -----------------------------------------------------------------------------
+# PROJECT-LOCAL CONFIG (.wt.yaml)
+# -----------------------------------------------------------------------------
+# For project-specific settings, create a .wt.yaml file at your repository root.
+# This file is committed to version control and shared with your team.
+#
+# Example .wt.yaml for a Rust project:
+#
+# hooks:
+#   on_worktree_create:
+#     - run: "cargo fetch"
+#       cwd: "{worktree_path}"
+#     - run: "cargo build"
+#       cwd: "{worktree_path}"
+#       background: true
+#
+# tmux:
+#   attach_on_create: false  # Override global setting
+#
+# worktree:
+#   location: "per-repo"  # Use .worktrees/ inside repo
+#
+# The project config will overlay these settings on top of your global config.
+# Arrays like hooks are replaced entirely (not merged), so define all hooks
+# you need in the project config.
+# -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Updates `.gitignore` to properly ignore project-local wt config
- Adds `.wt.yaml` as an example configuration file for wt tool

## Test plan
- [ ] Verify `.wt.yaml.example` syntax is valid YAML
- [ ] Confirm `.gitignore` correctly ignores local config files

🤖 Generated with [Claude Code](https://claude.com/claude-code)