### PR TITLE
refactor: remove unused background/parallel hook fields and dead code

### DIFF
--- a/.wt.yaml
+++ b/.wt.yaml
@@ -17,7 +17,6 @@ hooks:
   on_worktree_create:
     - run: "make build"
       cwd: "{worktree_path}"
-      background: true
 
   on_worktree_remove:
     # Example: Clean up on remove
@@ -70,7 +69,6 @@ worktree:
 #       cwd: "{worktree_path}"
 #     - run: "cargo build"
 #       cwd: "{worktree_path}"
-#       background: true
 #
 # tmux:
 #   attach_on_create: false  # Override global setting

--- a/.wt.yaml.example
+++ b/.wt.yaml.example
@@ -18,12 +18,6 @@ hooks:
     # Example: Install Node.js dependencies
     - run: "npm install"
       cwd: "{worktree_path}"
-      background: false
-
-    # Example: Run build in background
-    - run: "npm run build"
-      cwd: "{worktree_path}"
-      background: true
 
   on_worktree_remove:
     # Example: Clean up on remove
@@ -76,7 +70,6 @@ worktree:
 #       cwd: "{worktree_path}"
 #     - run: "cargo build"
 #       cwd: "{worktree_path}"
-#       background: true
 #
 # tmux:
 #   attach_on_create: false  # Override global setting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,13 +279,10 @@ Both services use the same logic: check `cfg.Worktree.IsDedicated()` and call `c
 Hooks are defined in config with these fields:
 - `run`: Command to execute
 - `cwd`: Working directory (supports `{worktree_path}` template)
-- `background`: Run asynchronously
-- `parallel`: Can run with other parallel hooks
 
 The executor (`pkg/executor/`) handles:
 - Context cancellation
 - Per-hook timeout (default 5 minutes)
-- Parallel execution
 - Output capture
 
 **4. Global CLI State**

--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ hooks:
   on_worktree_create:
     - run: "npm install"
       cwd: "{worktree_path}"  # Supports template variable
-      background: false
 ```
 
 ### Git-Spice Configuration

--- a/docs/plans/2025-02-08-wt-done-command-design.md
+++ b/docs/plans/2025-02-08-wt-done-command-design.md
@@ -87,11 +87,8 @@ hooks:
   # Runs after everything is complete (worktree gone)
   on_worktree_remove:
     - run: gh issue close $ISSUE_ID --comment "Merged via wt done"
-      background: true
     - run: slack-notify "Merged {branch} to main"
-      background: true
     - run: trigger-deployment {branch}
-      background: true
 ```
 
 **Hook Template Variables:**

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -194,13 +194,6 @@ hooks:
   on_worktree_create:
     - run: "npm install"
       cwd: "{worktree_path}"             # Template expansion NOT YET IMPLEMENTED
-      background: false                  # Run synchronously
-      parallel: false                    # Can run with other parallel hooks
-
-    - run: "npm run build"
-      cwd: "{worktree_path}"             # Template expansion NOT YET IMPLEMENTED
-      background: true                   # Run asynchronously
-      parallel: true                     # Can run in parallel with other parallel hooks
 
   on_worktree_remove:
     - run: "rm -rf node_modules"
@@ -382,16 +375,12 @@ hooks:
   on_worktree_create:
     - run: "npm install"
       cwd: "/absolute/path/to/project"  # Use absolute paths (template expansion not yet available)
-      background: true
-      parallel: true
 
     - run: "npm run build"
       cwd: "/absolute/path/to/project"  # Use absolute paths (template expansion not yet available)
-      background: true
-      parallel: true
 ```
 
-Now when you run `wt add feature/new`, dependencies are installed and the project is built automatically in the background.
+Now when you run `wt add feature/new`, dependencies are installed and the project is built automatically.
 
 **Note**: The `{worktree_path}` template expansion is not yet implemented. Use absolute paths or manage working directories manually for now.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,10 +37,8 @@ type HooksConfig struct {
 
 // Hook represents a single command to run
 type Hook struct {
-	Run        string `yaml:"run"`
-	Cwd        string `yaml:"cwd,omitempty"`
-	Background bool   `yaml:"background,omitempty"`
-	Parallel   bool   `yaml:"parallel,omitempty"`
+	Run string `yaml:"run"`
+	Cwd string `yaml:"cwd,omitempty"`
 }
 
 // TmuxConfig contains tmux-specific settings

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -101,28 +101,3 @@ func (e *Executor) Run(ctx context.Context, workdir string, command string) *Hoo
 
 	return result
 }
-
-// RunParallel executes multiple hooks in parallel
-func (e *Executor) RunParallel(ctx context.Context, hooks []HookDefinition) []HookResult {
-	results := make([]HookResult, len(hooks))
-	resultChan := make(chan *HookResult, len(hooks))
-
-	for i, hook := range hooks {
-		go func(_ int, h HookDefinition) {
-			resultChan <- e.Run(ctx, h.Workdir, h.Command)
-		}(i, hook)
-	}
-
-	for i := 0; i < len(hooks); i++ {
-		result := <-resultChan
-		results[i] = *result
-	}
-
-	return results
-}
-
-// HookDefinition represents a hook to execute
-type HookDefinition struct {
-	Command string
-	Workdir string
-}

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -161,29 +161,6 @@ func TestExecutor_VerboseLogging_LevelZero(t *testing.T) {
 	}
 }
 
-func TestExecutor_RunParallel(t *testing.T) {
-	e := New()
-	ctx := context.Background()
-
-	hooks := []HookDefinition{
-		{Command: "echo one"},
-		{Command: "echo two"},
-		{Command: "echo three"},
-	}
-
-	results := e.RunParallel(ctx, hooks)
-
-	if len(results) != 3 {
-		t.Fatalf("expected 3 results, got %d", len(results))
-	}
-
-	for i, result := range results {
-		if !result.Success {
-			t.Fatalf("result %d expected success, got error: %v", i, result.Error)
-		}
-	}
-}
-
 func TestExecutor_GetVerboseLevel(t *testing.T) {
 	e := New()
 


### PR DESCRIPTION
## Summary
- Remove unimplemented `Background` and `Parallel` fields from `Hook` struct
- Remove dead code: `RunParallel()` and `HookDefinition` from executor package
- Clean up all documentation and config examples

## Rationale
These fields were defined in the schema but never implemented in `hook_runner.go`. Following YAGNI principle, remove until there's a concrete use case.

## Test plan
- [x] All tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] Code formatted (`make fmt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)