### PR TITLE
fix: handle existing worktree in wt add as valid case

### DIFF
--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/joebalancio/wt/internal/git"
 	"github.com/joebalancio/wt/internal/picker"
@@ -117,6 +118,15 @@ Run this command from the main repository instead:
 		Fatal("Failed to create service: %v", err)
 	}
 
+	// Get or create worktree
+	wt := getOrCreateWorktree(ctx, svc, branch, base, path, force, track, noCheckout, cmd.OutOrStdout())
+
+	// Setup tmux window and run hooks
+	setupWorktreeWithTmux(ctx, cmd, wt.Branch, wt.Path, run)
+}
+
+// getOrCreateWorktree returns an existing worktree for the branch or creates a new one
+func getOrCreateWorktree(ctx context.Context, svc *worktree.Service, branch, base, path string, force bool, track string, noCheckout bool, stdout interface{ io.Writer }) *domain.Worktree {
 	spec := domain.WorktreeCreateSpec{
 		Branch:   branch,
 		Base:     base,
@@ -129,17 +139,22 @@ Run this command from the main repository instead:
 		spec.Track = &track
 	}
 
-	wt, err := svc.Add(ctx, spec)
+	wt, created, err := svc.GetOrCreate(ctx, spec)
 	if err != nil {
-		Fatal("Failed to add worktree: %v", err)
+		Fatal("Failed to get or create worktree: %v", err)
 	}
 
-	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Created worktree: %s [%s]\n", wt.Path, wt.Branch); err != nil {
-		Fatal("Failed to write output: %v", err)
+	// Output appropriate message
+	if created {
+		if _, err := fmt.Fprintf(stdout, "Created worktree: %s [%s]\n", wt.Path, wt.Branch); err != nil {
+			Fatal("Failed to write output: %v", err)
+		}
+	} else {
+		if _, err := fmt.Fprintf(stdout, "Selected worktree: %s [%s]\n", wt.Path, wt.Branch); err != nil {
+			Fatal("Failed to write output: %v", err)
+		}
 	}
-
-	// Setup tmux window and run hooks
-	setupWorktreeWithTmux(ctx, cmd, wt.Branch, wt.Path, run)
+	return wt
 }
 
 // setupWorktreeWithTmux creates tmux window before running hooks

--- a/internal/worktree/service.go
+++ b/internal/worktree/service.go
@@ -92,6 +92,32 @@ func (s *Service) Add(ctx context.Context, spec domain.WorktreeCreateSpec) (*dom
 	return worktree, nil
 }
 
+// GetOrCreate returns an existing worktree for the branch or creates a new one.
+// Returns (worktree, created, error) where created is true if a new worktree was created.
+func (s *Service) GetOrCreate(ctx context.Context, spec domain.WorktreeCreateSpec) (*domain.Worktree, bool, error) {
+	if spec.Branch == "" {
+		return nil, false, fmt.Errorf("branch is required")
+	}
+
+	// Check if a worktree already exists for this branch
+	existingWorktrees, err := s.List(ctx, &domain.WorktreeFilter{Branches: []string{spec.Branch}})
+	if err != nil {
+		return nil, false, fmt.Errorf("checking existing worktrees: %w", err)
+	}
+
+	if len(existingWorktrees) > 0 {
+		// Worktree exists - return it
+		return existingWorktrees[0], false, nil
+	}
+
+	// No worktree exists - create new one
+	worktree, err := s.Add(ctx, spec)
+	if err != nil {
+		return nil, false, err
+	}
+	return worktree, true, nil
+}
+
 // ResolvePath returns the worktree path for a branch.
 // If explicitPath is provided, it's used as-is.
 // Otherwise, path is resolved from config based on worktree.location setting.

--- a/internal/worktree/service_test.go
+++ b/internal/worktree/service_test.go
@@ -315,6 +315,145 @@ func TestService_Add(t *testing.T) {
 	})
 }
 
+func TestService_GetOrCreate(t *testing.T) {
+	t.Run("returns error when branch is empty", func(t *testing.T) {
+		mock := &mockGitClient{}
+
+		cfg := config.DefaultConfig()
+		svc, err := NewService(mock, cfg)
+		if err != nil {
+			t.Fatalf("NewService() error = %v", err)
+		}
+
+		spec := domain.WorktreeCreateSpec{Branch: ""}
+		_, _, err = svc.GetOrCreate(context.Background(), spec)
+		if err == nil {
+			t.Fatal("GetOrCreate() expected error for empty branch, got nil")
+		}
+		if err.Error() != "branch is required" {
+			t.Errorf("expected 'branch is required', got %q", err.Error())
+		}
+	})
+
+	t.Run("returns existing worktree when branch already has one", func(t *testing.T) {
+		mock := &mockGitClient{
+			listWorktreesFunc: func(_ context.Context) ([]*domain.Worktree, error) {
+				return []*domain.Worktree{
+					{Path: "/repo", Branch: "main"},
+					{Path: "/worktrees/existing-feature", Branch: "existing-feature"},
+				}, nil
+			},
+			getRepoInfoFunc: func(_ context.Context) (*domain.GitRepo, error) {
+				return &domain.GitRepo{RootPath: "/repo", DefaultBranch: "main"}, nil
+			},
+		}
+
+		cfg := config.DefaultConfig()
+		svc, err := NewService(mock, cfg)
+		if err != nil {
+			t.Fatalf("NewService() error = %v", err)
+		}
+
+		spec := domain.WorktreeCreateSpec{Branch: "existing-feature"}
+		worktree, created, err := svc.GetOrCreate(context.Background(), spec)
+		if err != nil {
+			t.Fatalf("GetOrCreate() error = %v", err)
+		}
+		if created {
+			t.Error("expected created=false for existing worktree, got true")
+		}
+		if worktree.Branch != "existing-feature" {
+			t.Errorf("got branch %s, want existing-feature", worktree.Branch)
+		}
+		if worktree.Path != "/worktrees/existing-feature" {
+			t.Errorf("got path %s, want /worktrees/existing-feature", worktree.Path)
+		}
+	})
+
+	t.Run("creates new worktree when branch has none", func(t *testing.T) {
+		mock := &mockGitClient{
+			listWorktreesFunc: func(_ context.Context) ([]*domain.Worktree, error) {
+				return []*domain.Worktree{
+					{Path: "/repo", Branch: "main"},
+				}, nil
+			},
+			getRepoInfoFunc: func(_ context.Context) (*domain.GitRepo, error) {
+				return &domain.GitRepo{RootPath: "/repo", DefaultBranch: "main"}, nil
+			},
+			addWorktreeFunc: func(_ context.Context, spec domain.WorktreeCreateSpec) (*domain.Worktree, error) {
+				return &domain.Worktree{
+					Path:   "/worktrees/" + spec.Branch,
+					Branch: spec.Branch,
+				}, nil
+			},
+		}
+
+		cfg := config.DefaultConfig()
+		svc, err := NewService(mock, cfg)
+		if err != nil {
+			t.Fatalf("NewService() error = %v", err)
+		}
+
+		spec := domain.WorktreeCreateSpec{Branch: "new-feature"}
+		worktree, created, err := svc.GetOrCreate(context.Background(), spec)
+		if err != nil {
+			t.Fatalf("GetOrCreate() error = %v", err)
+		}
+		if !created {
+			t.Error("expected created=true for new worktree, got false")
+		}
+		if worktree.Branch != "new-feature" {
+			t.Errorf("got branch %s, want new-feature", worktree.Branch)
+		}
+	})
+
+	t.Run("returns error when listing worktrees fails", func(t *testing.T) {
+		mock := &mockGitClient{
+			listWorktreesFunc: func(_ context.Context) ([]*domain.Worktree, error) {
+				return nil, fmt.Errorf("git error")
+			},
+		}
+
+		cfg := config.DefaultConfig()
+		svc, err := NewService(mock, cfg)
+		if err != nil {
+			t.Fatalf("NewService() error = %v", err)
+		}
+
+		spec := domain.WorktreeCreateSpec{Branch: "some-branch"}
+		_, _, err = svc.GetOrCreate(context.Background(), spec)
+		if err == nil {
+			t.Fatal("GetOrCreate() expected error when listing fails, got nil")
+		}
+	})
+
+	t.Run("returns error when creating worktree fails", func(t *testing.T) {
+		mock := &mockGitClient{
+			listWorktreesFunc: func(_ context.Context) ([]*domain.Worktree, error) {
+				return []*domain.Worktree{{Path: "/repo", Branch: "main"}}, nil
+			},
+			getRepoInfoFunc: func(_ context.Context) (*domain.GitRepo, error) {
+				return &domain.GitRepo{RootPath: "/repo", DefaultBranch: "main"}, nil
+			},
+			addWorktreeFunc: func(_ context.Context, _ domain.WorktreeCreateSpec) (*domain.Worktree, error) {
+				return nil, fmt.Errorf("git worktree add failed")
+			},
+		}
+
+		cfg := config.DefaultConfig()
+		svc, err := NewService(mock, cfg)
+		if err != nil {
+			t.Fatalf("NewService() error = %v", err)
+		}
+
+		spec := domain.WorktreeCreateSpec{Branch: "new-feature"}
+		_, _, err = svc.GetOrCreate(context.Background(), spec)
+		if err == nil {
+			t.Fatal("GetOrCreate() expected error when creation fails, got nil")
+		}
+	})
+}
+
 func TestService_Remove(t *testing.T) {
 	t.Run("removes worktree", func(t *testing.T) {
 		mock := &mockGitClient{


### PR DESCRIPTION
## Summary
- When selecting a branch that already has a worktree via the picker, `wt add` now returns the existing worktree instead of failing with a cryptic git error
- The flow continues with tmux/hooks setup as expected
- Added `GetOrCreate` method to `worktree.Service` for idempotent worktree creation

## Changes
- **Service layer**: Added `GetOrCreate(ctx, spec) (*Worktree, bool, error)` method that checks for existing worktrees before creating new ones
- **CLI layer**: Updated to use `GetOrCreate` with appropriate user messages ("Selected worktree" vs "Created worktree")
- **Validation**: Added early validation for empty branch name
- **Tests**: Added 5 unit tests covering all `GetOrCreate` scenarios

## Test Plan
- [x] Unit tests pass: `go test -v -run TestService_GetOrCreate ./internal/worktree/`
- [x] All tests pass: `go test ./...`
- [x] Lint clean: `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)